### PR TITLE
Don't fail when using nocache build

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -272,6 +272,9 @@ polygon.rs-logo-shape {
 .rs-sync:hover .rs-icon {
   fill: #FFBB0C;
 }
+.rs-sync.hidden {
+  display: none;
+}
 .rs-sync.rs-rotate {
   border-color: #FFBB0C;
 }

--- a/src/widget.js
+++ b/src/widget.js
@@ -94,7 +94,7 @@ RemoteStorageWidget.prototype = {
     this.rs.on('connected', () => {
       console.debug('RS CONNECTED');
 
-      if (this.rs.sync) {
+      if (this.rs.hasFeature('Sync')) {
         this.rs.sync.on('req-done', () => {
           console.debug('SYNC REQ DONE');
           this.rsSyncButton.classList.add('rs-rotate');
@@ -220,7 +220,7 @@ RemoteStorageWidget.prototype = {
     });
 
     // Sync button
-    if (this.rs.sync) {
+    if (this.rs.hasFeature('Sync')) {
       this.rsSyncButton.addEventListener('click', () => {
         if (this.rsSyncButton.classList.contains('rs-rotate')) {
           this.rs.stopSync();

--- a/src/widget.js
+++ b/src/widget.js
@@ -94,25 +94,29 @@ RemoteStorageWidget.prototype = {
     this.rs.on('connected', () => {
       console.debug('RS CONNECTED');
 
-      this.rs.sync.on('req-done', () => {
-        console.debug('SYNC REQ DONE');
-        this.rsSyncButton.classList.add('rs-rotate');
-      });
-      this.rs.sync.on('done', () => {
-        console.debug('SYNC DONE');
-        if (this.rsWidget.classList.contains('rs-state-unauthorized') ||
-            !this.rs.remote.online) {
-          this.updateLastSyncedOutput();
-        } else if (this.rs.remote.online) {
-          this.lastSynced = new Date();
-          console.debug('Set lastSynced to', this.lastSynced);
-          let subHeadlineEl = document.querySelector('.rs-box-connected .rs-sub-headline');
-          this.fadeOut(subHeadlineEl);
-          subHeadlineEl.innerHTML = 'Synced just now';
-          this.delayFadeIn(subHeadlineEl, 300);
-        }
-        this.rsSyncButton.classList.remove('rs-rotate');
-      });
+      if (this.rs.sync) {
+        this.rs.sync.on('req-done', () => {
+          console.debug('SYNC REQ DONE');
+          this.rsSyncButton.classList.add('rs-rotate');
+        });
+        this.rs.sync.on('done', () => {
+          console.debug('SYNC DONE');
+          if (this.rsWidget.classList.contains('rs-state-unauthorized') ||
+              !this.rs.remote.online) {
+            this.updateLastSyncedOutput();
+          } else if (this.rs.remote.online) {
+            this.lastSynced = new Date();
+            console.debug('Set lastSynced to', this.lastSynced);
+            let subHeadlineEl = document.querySelector('.rs-box-connected .rs-sub-headline');
+            this.fadeOut(subHeadlineEl);
+            subHeadlineEl.innerHTML = 'Synced just now';
+            this.delayFadeIn(subHeadlineEl, 300);
+          }
+          this.rsSyncButton.classList.remove('rs-rotate');
+        });
+      } else {
+        this.rsSyncButton.classList.add('hidden');
+      }
 
       let connectedUser = this.rs.remote.userAddress;
       // TODO set user address/name in rs.js core
@@ -216,15 +220,17 @@ RemoteStorageWidget.prototype = {
     });
 
     // Sync button
-    this.rsSyncButton.addEventListener('click', () => {
-      if (this.rsSyncButton.classList.contains('rs-rotate')) {
-        this.rs.stopSync();
-        this.rsSyncButton.classList.remove("rs-rotate");
-      } else {
-        this.rs.startSync();
-        this.rsSyncButton.classList.add("rs-rotate");
-      }
-    });
+    if (this.rs.sync) {
+      this.rsSyncButton.addEventListener('click', () => {
+        if (this.rsSyncButton.classList.contains('rs-rotate')) {
+          this.rs.stopSync();
+          this.rsSyncButton.classList.remove("rs-rotate");
+        } else {
+          this.rs.startSync();
+          this.rsSyncButton.classList.add("rs-rotate");
+        }
+      });
+    }
 
     // Reduce to only icon if connected and clicked outside of widget
     document.addEventListener('click', () => {


### PR DESCRIPTION
When using the widget with the nocache build, it was throwing an exception.

When `rs.sync` is not defined, this hides the sync button and doesn't try to display any sync information.