### PR TITLE
Fix styles

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -32,7 +32,7 @@
 
 .rs-box.selected {
   opacity: 1;
-  max-height: 400px;
+  max-height: 410px;
 }
 
 /* Main logo */

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -123,6 +123,8 @@ polygon.rs-logo-shape {
   font-size: 1.625em;
   font-weight: normal;
   text-align: center;
+  margin-top: 20px;
+  margin-bottom: 20px;
 }
 
 /* BUTTONS  */
@@ -236,10 +238,7 @@ polygon.rs-logo-shape {
   text-align: center;
   overflow: hidden;
 }
-.rs-box-choose .rs-big-headline {
-  margin-top: 20px;
-  margin-bottom: 20px;
-}
+
 .rs-box-choose p {
   margin-top: 0;
   margin-bottom: 20px;

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -32,7 +32,7 @@
 
 .rs-box.selected {
   opacity: 1;
-  max-height: 410px;
+  max-height: 380px;
 }
 
 /* Main logo */

--- a/src/assets/widget.html
+++ b/src/assets/widget.html
@@ -213,8 +213,8 @@
   </svg>
 
   <div class="rs-box rs-box-initial">
-    <h3 class="rs-small-headline">Connect Remote Storage</h3>
-    <span class="rs-sub-headline">To own and control your data</span>
+    <h3 class="rs-small-headline">Connect your storage</h3>
+    <span class="rs-sub-headline">To sync data with your account</span>
   </div>
 
   <div class="rs-box rs-box-connected">
@@ -246,13 +246,10 @@
 
   <div class="rs-box rs-box-choose">
     <div class="rs-content">
-      <h1 class="rs-big-headline">Own Your Data</h1>
+      <h1 class="rs-big-headline">Connect your storage</h1>
       <p class="rs-short-desc">
-        This app allows you to own and control your data.
+        This app allows you to sync data with a storage of your choice.
         <a class="rs-help" href="https://remotestorage.io/" target="_blank">Read more</a>
-      </p>
-      <p class="rs-small-headline">
-        Please choose your storage:
       </p>
       <div class="rs-button-wrap">
         <button class="rs-button rs-button-big rs-choose-rs">


### PR DESCRIPTION
Fixes #20 

I just had to move the margins for the big headline of the first view ("Own Your Data") to also be used for the "Connect your storage" headline.

I also noticed that when all 3 backends are enabled, the button for the last backend (Google Drive) is cut off at the bottom (see screenshot). I increased the overall max-height by 10 pixels to fix that.

![rs-widget](https://user-images.githubusercontent.com/843/31386204-42e25b5e-adc6-11e7-839f-54ca764fb2f3.png)

