### PR TITLE
Increase the height of the user id line

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -107,7 +107,7 @@ polygon.rs-logo-shape {
   font-weight: bold;
   margin: 0;
   margin-bottom: 2px;
-  height: 1.1em;
+  height: 1.2em;
   word-break: break-all;
   overflow: hidden;
 }


### PR DESCRIPTION
Its height was set to make the animation look smooth (84ca7ac5), but on
macOS the line height is not enough for some gliphs

Fixes #34