### PR TITLE
Truncate too long user addresses with ellipsis

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -253,6 +253,10 @@ polygon.rs-logo-shape {
 }
 .rs-box-connected .rs-user {
   font-weight: bold;
+  max-width: 210px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: keep-all;
 }
 .rs-connected-buttons {
   float: right;


### PR DESCRIPTION
Refs #39 

Probably not the best solution, but at least it keeps the buttons around :)

![widget](https://user-images.githubusercontent.com/843/31508544-b68bf68c-af7e-11e7-97d0-35e33a2d8171.png)
