### PR TITLE
Fix content jumping around

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -79,7 +79,7 @@ polygon.rs-logo-shape {
 
 /* Hide everything except logo when connected and clicked outside of box */
 .rs-state-close {
-  max-width: 55px;
+  max-width: 36px;
   background-color: transparent;
   box-shadow: none;
   opacity: 0.5;

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -250,6 +250,7 @@ polygon.rs-logo-shape {
 /*Connected box */
 .rs-box-connected {
   height: 40px;
+  transition: height 0s;
 }
 .rs-connected-text {
   float: left;

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -92,7 +92,10 @@ polygon.rs-logo-shape {
   opacity: 1;
 }
 
-/* Initial Connect remote storage box */
+.rs-box-initial {
+  transition-duration: 0ms;
+}
+
 .rs-box-initial:hover {
   cursor: pointer;
 }

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -190,7 +190,6 @@ polygon.rs-logo-shape {
   float: none;
 }
 
-
 .rs-sign-in-form input[type=text] {
   padding: 15px 10px;
   display: block;
@@ -245,6 +244,7 @@ polygon.rs-logo-shape {
 .rs-box-choose p {
   margin-top: 0;
   margin-bottom: 20px;
+  line-height: 1.4em;
 }
 
 /*Connected box */


### PR DESCRIPTION
The icon is floating left, but switching to not be floating in the open dialogs, while the initial box only transitions to its zero height for the default transition duration.

fixes #44