### PR TITLE
Reset to initial state when getting an access denied error

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -397,10 +397,14 @@ Widget.prototype = {
   },
 
   handleUnauthorized (error) {
-    this.openWidget();
-    this.showErrorBox(error.message + " ");
-    this.rsErrorBox.appendChild(this.rsErrorReconnectLink);
-    this.rsErrorReconnectLink.classList.remove('hidden');
+    if (error.code && error.code === 'access_denied') {
+      this.rs.disconnect();
+    } else {
+      this.openWidget();
+      this.showErrorBox(error.message + " ");
+      this.rsErrorBox.appendChild(this.rsErrorReconnectLink);
+      this.rsErrorReconnectLink.classList.remove('hidden');
+    }
   },
 
   updateLastSyncedOutput () {


### PR DESCRIPTION
Instead of showing an error message when the user denies access during the OAuth dance, the widget just goes back to the initial state.

This needs the changes from remotestorage/remotestorage.js#1018 to work, as it adds the custom `code` property to the error.