### PR TITLE
Make logging configurable, disable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The widget has some configuration options to customize the behavior:
 |---|---|---|---|
 | `leaveOpen` | Keep the widget open when user clicks outside of it | Boolean | false |
 | `autoCloseAfter` | Timeout after which the widget closes automatically (in milliseconds). The widget only closes when a storage is connected. | Number | 1500 |
+| `logging` | Enable logging for debugging purposes | Boolean | false |
 
 Example:
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,7 @@
     remoteStorage.access.claim('bookmarks', 'rw');
     remoteStorage.caching.enable('/bookmarks/');
 
-    var widget = new Widget(remoteStorage);
+    var widget = new Widget(remoteStorage, { logging: true });
     widget.attach();
   </script>
 </body>

--- a/src/widget.js
+++ b/src/widget.js
@@ -8,6 +8,7 @@
  *                                      outside of it (default: false)
  * @param {number} options.autoCloseAfter - Time after which the widget closes
  *                                          automatically in ms (default: 1500)
+ * @param {boolean} options.logging - Enable logging (default: false)
  */
 let Widget = function(remoteStorage, options={}) {
   this.rs = remoteStorage;
@@ -25,6 +26,8 @@ let Widget = function(remoteStorage, options={}) {
 
   this.leaveOpen = options.leaveOpen ? options.leaveOpen : false;
 
+  this.logging = typeof options.logging === 'boolean' ? options.logging : false;
+
   this.autoCloseAfter = options.autoCloseAfter ? options.autoCloseAfter : 1500;
 
   this.lastSynced = null;
@@ -35,7 +38,9 @@ let Widget = function(remoteStorage, options={}) {
 Widget.prototype = {
 
   log (...msg) {
-    console.debug('[RS-WIDGET] ', ...msg);
+    if (this.logging) {
+      console.debug('[RS-WIDGET] ', ...msg);
+    }
   },
 
   // handle events !


### PR DESCRIPTION
I thought the release version of the widget shouldn't pollute the console so much, so I made the logging configurable.

For the demo it's still enabled.