### PR TITLE
Add width for closed state

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -321,6 +321,9 @@ polygon.rs-logo-shape {
     top: auto;
     right: auto
   }
+  .rs-state-close {
+    max-width: 56px;
+  }
   .rs-state-choose,
   .rs-state-sign-in {
     position: fixed;


### PR DESCRIPTION
Without this, it uses the rs-widget main div's max-width, which is
400px on small screens.