### PR TITLE
Fix button shape in mobile Safari

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -347,3 +347,9 @@ polygon.rs-logo-shape {
 .rs-widget input[type="submit"]::-moz-focus-inner {
   border:0;
 }
+
+/* prevent rounded buttons on mobile Safari */
+.rs-widget input[type="button"],
+.rs-widget input[type="submit"] {
+  -webkit-appearance: none;
+}

--- a/src/assets/widget.html
+++ b/src/assets/widget.html
@@ -476,7 +476,7 @@
     <div class="rs-content">
       <form name="rs-sign-in-form" class="rs-sign-in-form">
         <h1 class="rs-big-headline">Connect your storage</h1>
-        <input type="text" name='rs-user-address' placeholder="user@provider.com">
+        <input type="text" name='rs-user-address' placeholder="user@provider.com" autocapitalize="off">
         <div class="rs-sign-in-error rs-hidden"></div>
         <input type="submit" value="Connect">
         <a href="https://remotestorage.io/get/" class="rs-help" target="_blank">Need help?</a>


### PR DESCRIPTION
Fixes #67

This fixes the pill-shaped button in mobile Safari.

I also disabled the auto-capitalization of the first letter for the storage address input field.