### PR TITLE
Use flexbox for better arrangement of content and buttons

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -252,9 +252,12 @@ polygon.rs-logo-shape,
   color: darkred;
 }
 
+.rs-box-error {
+  display: flex;
+}
+
 .rs-box-error .rs-error-message {
-  float: left;
-  max-width: 242px;
+  flex: auto;
 }
 
  /*Choose provider box */
@@ -271,21 +274,22 @@ polygon.rs-logo-shape,
 
 /*Connected box */
 .rs-box-connected {
+  display: flex;
   height: 40px;
   transition: height 0s;
 }
 .rs-connected-text {
-  float: left;
+  flex: auto;
+  min-width: 0;
 }
 .rs-box-connected .rs-user {
   font-weight: bold;
-  max-width: 210px;
   text-overflow: ellipsis;
   overflow: hidden;
   word-break: keep-all;
 }
 .rs-connected-buttons, .rs-error-buttons {
-  float: right;
+  flex: none;
 }
 .rs-disconnect:hover {
   border-color: #FF2D2D;

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -254,6 +254,7 @@ polygon.rs-logo-shape,
 
 .rs-box-error {
   display: flex;
+  flex-direction: row;
 }
 
 .rs-box-error .rs-error-message {
@@ -275,6 +276,7 @@ polygon.rs-logo-shape,
 /*Connected box */
 .rs-box-connected {
   display: flex;
+  flex-direction: row;
   height: 40px;
   transition: height 0s;
 }


### PR DESCRIPTION
Fixes #39

This way, the buttons will never be pushed out of view, and the content just uses the remaining space.