### PR TITLE
Don't try to call `getTime()` on null

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -432,6 +432,7 @@ Widget.prototype = {
   },
 
   updateLastSyncedOutput () {
+    if (!this.lastSynced) { return } // don't do anything when we've never synced yet
     let now = new Date();
     let secondsSinceLastSync = Math.round((now.getTime() - this.lastSynced.getTime())/1000);
     let subHeadlineEl = document.querySelector('.rs-box-connected .rs-sub-headline');


### PR DESCRIPTION
This happens e.g. when loading an app while offline.