### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # remotestorage-widget
 
+[![npm](https://img.shields.io/npm/v/remotestorage-widget.svg)](https://www.npmjs.com/package/remotestorage-widget)
+[![Dependency Status](http://img.shields.io/david/remotestorage/remotestorage-widget.svg?style=flat)](https://david-dm.org/remotestorage/remotestorage-widget#info=dependencies)
+[![devDependency Status](http://img.shields.io/david/dev/remotestorage/remotestorage-widget.svg?style=flat)](https://david-dm.org/remotestorage/remotestorage-widget#info=devDependencies)
+
 A ready-to-use connect/sync widget, as add-on library for
 [remoteStorage.js](https://github.com/remotestorage/remotestorage.js/).
 


### PR DESCRIPTION
NPM package and dependency status

(You can click the "view" button for README.md in the "Files changed" tab in order to check this change.)

P.S.: After adding the David DM badges, I saw that we use a very old Webpack and some other outdated deps, and wondered if that's the reason for the borked sourcemaps in FF 57+. Should definitely upgrade soon. https://david-dm.org/remotestorage/remotestorage-widget?type=dev