### PR TITLE
Add config option for skipping the initial state

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,12 @@
     remoteStorage.access.claim('bookmarks', 'rw');
     remoteStorage.caching.enable('/bookmarks/');
 
-    var widget = new Widget(remoteStorage, { logging: true });
+    var widget = new Widget(remoteStorage, {
+      //leaveOpen: true,
+      //autoCloseAfter: 2000,
+      // skipInitial: true,
+      logging: true
+    });
     widget.attach();
   </script>
 </body>

--- a/src/widget.js
+++ b/src/widget.js
@@ -10,6 +10,7 @@
  *                                           automatically in ms (default: 1500)
  * @param {boolean} options.skipInitial    - Don't show the initial connect hint,
  *                                           but show sign-in screen directly instead
+ *                                           (default: false)
  * @param {boolean} options.logging        - Enable logging (default: false)
  */
 let Widget = function(remoteStorage, options={}) {


### PR DESCRIPTION
This adds a new option for app developers, so they can hide the initial connect hint and instead show the sign-in (or choose-backend) dialog directly.

This is useful when you just want to integrate the sign-in dialog from the widget (with the errors and all), but not much else. You can try it in action with Inspektor right now (also includes the code from #78):

https://inspektor.5apps.com/