### PR TITLE
Ensure widget is opened on disconnect

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -69,7 +69,6 @@ Widget.prototype = {
         }
         break;
       case 'disconnected':
-        console.log('disconnected event handler');
         this.active = false;
         this.setOnline();
         this.setBackendClass(); // removes all backend CSS classes

--- a/src/widget.js
+++ b/src/widget.js
@@ -69,9 +69,11 @@ Widget.prototype = {
         }
         break;
       case 'disconnected':
+        console.log('disconnected event handler');
         this.active = false;
         this.setOnline();
         this.setBackendClass(); // removes all backend CSS classes
+        this.open();
         this.setInitialState();
         break;
       case 'connected':


### PR DESCRIPTION
When using the normal UI for disconnecting one has to open the widget to click the button. However, when using custom UI to trigger the disconnect, and the widget is in closed state, it won't open and then get into a slightly broken in-between state.

This ensures the widget is always opened on disconnect. Not sure if it's the best place to put the open() call though.

fixes #77
replaces #78