### PR TITLE
Create bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+    "name": "rs-widget",
+    "version": "1.2.0",
+    "description": "Connect widget for remoteStorage.js",
+    "main": [
+        "./build/widget.js"
+    ],
+    "license": "MIT",
+    "homepage": "https://github.com/remotestorage/remotestorage-widget",
+    "keywords": [
+      "localstorage", "indexeddb", "storage", "offline", "no-backend",
+      "unhosted", "offline-first", "remotestorage"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "NODE_ENV=production webpack -p",
     "dev": "webpack-dev-server --inline --hot --content-base demo --port 8008",
     "open": "opener http://localhost:8008",
-    "version": "npm run build && git add build/"
+    "version": "npm run build && git add build/ && npm run update-bower-version && git add bower.json",
+    "update-bower-version": "./scripts/update-bower-version.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/update-bower-version.sh
+++ b/scripts/update-bower-version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+sed -i.bak -E "s/\"version\": \"(.*)\"/\"version\": \"$(node -p "var config = require('./package.json'); config.version")\"/" bower.json
+rm bower.json.bak


### PR DESCRIPTION
We need this merged before we can register the package ([see the docs](https://bower.io/docs/creating-packages/#register)). I have tried this locally (`bower install /path/to/your/remotestorage-widget --save`.

Fixes #82