### PR TITLE
Disable connect button when connecting

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -235,6 +235,10 @@ polygon.rs-logo-shape,
 .rs-sign-in-form input[type=submit]:active {
   background-color: #3fb34f;
 }
+.rs-sign-in-form input[type=submit]:disabled,
+.rs-sign-in-form input[type=submit]:disabled:hover {
+  background-color: #aaa;
+}
 
 .rs-sign-in-error.rs-hidden,
 .rs-box-error.rs-hidden {

--- a/src/assets/widget.html
+++ b/src/assets/widget.html
@@ -473,7 +473,7 @@
     <div class="rs-content">
       <form name="rs-sign-in-form" class="rs-sign-in-form">
         <h1 class="rs-big-headline">Connect your storage</h1>
-        <input type="text" name='rs-user-address' placeholder="user@provider.com" autocapitalize="off">
+        <input type="text" name="rs-user-address" placeholder="user@provider.com" autocapitalize="off">
         <div class="rs-sign-in-error rs-hidden"></div>
         <input type="submit" class="rs-connect" value="Connect">
         <a href="https://remotestorage.io/get/" class="rs-help" target="_blank">Need help?</a>

--- a/src/assets/widget.html
+++ b/src/assets/widget.html
@@ -475,7 +475,7 @@
         <h1 class="rs-big-headline">Connect your storage</h1>
         <input type="text" name='rs-user-address' placeholder="user@provider.com" autocapitalize="off">
         <div class="rs-sign-in-error rs-hidden"></div>
-        <input type="submit" value="Connect">
+        <input type="submit" class="rs-connect" value="Connect">
         <a href="https://remotestorage.io/get/" class="rs-help" target="_blank">Need help?</a>
       </form>
     </div>

--- a/src/widget.js
+++ b/src/widget.js
@@ -197,6 +197,7 @@ Widget.prototype = {
     }
 
     this.rsSignInForm = document.querySelector('.rs-sign-in-form');
+    this.rsConnectButton = document.querySelector('.rs-connect');
 
     this.rsDisconnectButton = document.querySelector('.rs-disconnect');
     this.rsSyncButton = document.querySelector('.rs-sync');
@@ -256,6 +257,7 @@ Widget.prototype = {
     this.rsSignInForm.addEventListener('submit', (e) => {
       e.preventDefault();
       let userAddress = document.querySelector('input[name=rs-user-address]').value;
+      this.rsConnectButton.disabled = true;
       this.rs.connect(userAddress);
     });
   },
@@ -428,6 +430,7 @@ Widget.prototype = {
     msgContainer.innerHTML = error.message;
     msgContainer.classList.remove('rs-hidden');
     msgContainer.classList.add('rs-visible');
+    this.rsConnectButton.disabled = false;
   },
 
   handleSyncError (/* error */) {


### PR DESCRIPTION
Disables the connect button both visually and functionally upon pressing it, until either a discovery error appears, or it redirects to the storage provider's OAuth dialog.

connected to #26 