### PR TITLE
Set display: none on closed widget to hide it from screen readers

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -96,6 +96,7 @@ polygon.rs-logo-shape,
   background-color: transparent;
   box-shadow: none;
   opacity: 0.5;
+  display: none;
 
   transition: max-height 100ms ease-out 0ms, max-width 300ms ease-out 300ms, background 300ms ease-in 200ms, opacity 300ms ease 200ms; 
 }


### PR DESCRIPTION
Without this fix, as a screen reader user I always see the widget as being open even when it is connected. Would really appreciate any feedback preventing this from merging, if any, and a new release that incorporates it. Since I can't see the styling, I don't think this breaks anything but I can't conform that. Thanks!