### PR TITLE
Improve accessibility by marking hidden elements appropriately

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -97,7 +97,7 @@ polygon.rs-logo-shape,
   box-shadow: none;
   opacity: 0.5;
 
-  transition: max-height 100ms ease-out 0ms, max-width 300ms ease-out 300ms, background 300ms ease-in 200ms, opacity 300ms ease 200ms; 
+  transition: max-height 100ms ease-out 0ms, max-width 300ms ease-out 300ms, background 300ms ease-in 200ms, opacity 300ms ease 200ms;
 }
 
 .rs-closed:hover {
@@ -359,7 +359,7 @@ polygon.rs-logo-shape,
 .rs-widget input:focus {
   outline:none;
 }
-.rs-widget button::-moz-focus-inner, 
+.rs-widget button::-moz-focus-inner,
 .rs-widget input[type="button"]::-moz-focus-inner,
 .rs-widget input[type="submit"]::-moz-focus-inner {
   border:0;

--- a/src/assets/widget.html
+++ b/src/assets/widget.html
@@ -11,8 +11,7 @@
   rs-modal           - TODO - will make it a modal window
 -->
 
-<!-- RS WIDGET, a class named rs-state-<state> indicate
- its current state -->
+<!-- RS WIDGET, a class named rs-state-<state> indicates its current state -->
 <div class="rs-widget rs-state-initial">
 
   <div class="rs-widget-icon">
@@ -211,12 +210,12 @@
     </svg>
   </div>
 
-  <div class="rs-box rs-box-initial">
+  <div class="rs-box rs-box-initial" aria-hidden="false">
     <h3 class="rs-small-headline">Connect your storage</h3>
     <span class="rs-sub-headline">To sync data with your account</span>
   </div>
 
-  <div class="rs-box rs-box-connected">
+  <div class="rs-box rs-box-connected" aria-hidden="true">
     <div class="rs-connected-text">
       <h1 class="rs-user rs-small-headline">user@provider.com</h1>
       <span class="rs-sub-headline">Connected</span>
@@ -241,7 +240,7 @@
     </div>
   </div>
 
-  <div class="rs-box rs-box-error">
+  <div class="rs-box rs-box-error" aria-hidden="true">
     <div class="rs-error-message"></div>
     <div class="rs-error-buttons">
       <a href="#" class="rs-reconnect rs-hidden">Renew</a>
@@ -256,7 +255,7 @@
     </div>
   </div>
 
-  <div class="rs-box rs-box-choose">
+  <div class="rs-box rs-box-choose" aria-hidden="true">
     <div class="rs-content">
       <h1 class="rs-big-headline">Connect your storage</h1>
       <p class="rs-short-desc">
@@ -469,7 +468,7 @@
     </div>
   </div>
 
-  <div class="rs-box rs-box-sign-in">
+  <div class="rs-box rs-box-sign-in" aria-hidden="true">
     <div class="rs-content">
       <form name="rs-sign-in-form" class="rs-sign-in-form">
         <h1 class="rs-big-headline">Connect your storage</h1>

--- a/src/widget.js
+++ b/src/widget.js
@@ -120,11 +120,13 @@ Widget.prototype = {
       let lastSelected = document.querySelector('.rs-box.rs-selected');
       if (lastSelected) {
         lastSelected.classList.remove('rs-selected');
+        lastSelected.setAttribute('aria-hidden', 'true');
       }
 
       let toSelect = document.querySelector('.rs-box.rs-box-'+state);
       if (toSelect) {
         toSelect.classList.add('rs-selected');
+        toSelect.setAttribute('aria-hidden', 'false');
       }
 
       let currentStateClass = this.rsWidget.className.match(/rs-state-\S+/g)[0];
@@ -345,6 +347,11 @@ Widget.prototype = {
     this.closed = false;
     this.rsWidget.classList.remove('rs-closed');
     this.shouldCloseWhenSyncDone = false; // prevent auto-closing when user opened the widget
+
+    let selected = document.querySelector('.rs-box.rs-selected');
+    if (selected) {
+      selected.setAttribute('aria-hidden', 'false');
+    }
   },
 
   /**
@@ -360,6 +367,10 @@ Widget.prototype = {
     if (!this.leaveOpen && this.active) {
       this.closed = true;
       this.rsWidget.classList.add('rs-closed');
+      let selected = document.querySelector('.rs-box.rs-selected');
+      if (selected) {
+        selected.setAttribute('aria-hidden', 'true');
+      }
     } else if (this.active) {
       this.setState('connected');
     } else {


### PR DESCRIPTION
Right now elements are only hidden by setting the opacity to 0, which does not actually
hide them from screen readers.

This PR also sets the the `aria-hidden` attribute.

A demo of this version of the widget can be found at https://rs-widget-demo.5apps.com/. 