### PR TITLE
Focus address input on sign-in

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -121,24 +121,20 @@ Widget.prototype = {
   },
 
   setState (state) {
-    if (state) {
-      this.log('Setting state ', state);
-      let lastSelected = document.querySelector('.rs-box.rs-selected');
-      if (lastSelected) {
-        lastSelected.classList.remove('rs-selected');
-      }
+    if (!state) return;
+    this.log('Setting state ', state);
 
-      let toSelect = document.querySelector('.rs-box.rs-box-'+state);
-      if (toSelect) {
-        toSelect.classList.add('rs-selected');
-      }
+    let lastSelected = document.querySelector('.rs-box.rs-selected');
+    if (lastSelected) lastSelected.classList.remove('rs-selected');
 
-      let currentStateClass = this.rsWidget.className.match(/rs-state-\S+/g)[0];
-      this.rsWidget.classList.remove(currentStateClass);
-      this.rsWidget.classList.add(`rs-state-${state || this.state}`);
+    let toSelect = document.querySelector('.rs-box.rs-box-'+state);
+    if (toSelect) toSelect.classList.add('rs-selected');
 
-      this.state = state;
-    }
+    let currentStateClass = this.rsWidget.className.match(/rs-state-\S+/g)[0];
+    this.rsWidget.classList.remove(currentStateClass);
+    this.rsWidget.classList.add(`rs-state-${state || this.state}`);
+
+    this.state = state;
   },
 
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -228,6 +228,7 @@ Widget.prototype = {
     }
 
     this.rsSignInForm = document.querySelector('.rs-sign-in-form');
+    this.rsAddressInput = this.rsSignInForm.querySelector('input[name=rs-user-address]');
     this.rsConnectButton = document.querySelector('.rs-connect');
 
     this.rsDisconnectButton = document.querySelector('.rs-disconnect');
@@ -322,7 +323,10 @@ Widget.prototype = {
     this.rsInitial.addEventListener('click', () => this.showChooseOrSignIn() );
 
     // Choose RS button
-    this.rsChooseRemoteStorageButton.addEventListener('click', () => this.setState('sign-in') );
+    this.rsChooseRemoteStorageButton.addEventListener('click', () => {
+      this.setState('sign-in');
+      this.rsAddressInput.focus();
+    });
 
     // Choose Dropbox button
     this.rsChooseDropboxButton.addEventListener('click', () => this.rs["dropbox"].connect() );


### PR DESCRIPTION
Continuation of #93.

This focuses the address input field when selecting the RS option during sign-in.

The difference between this and @rosano's PR is that it does not focus the input when the widget opens the sign-in form immediately (without the options), because we don't want to mess with whatever other focus operations may be going on at rendering time, in the app that the widget is embedded in.