### PR TITLE
Optimize layout of small buttons

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -156,9 +156,12 @@ polygon.rs-logo-shape,
   cursor: pointer;
 }
 .rs-button-small {
-  padding: 0.5em 0.6em;
-  margin-left: 0.3em;
+  padding: 0.6em 0.7em;
+  margin-left: 0.2em;
   transition: border-color 300ms ease-out;
+}
+.rs-button-small svg {
+  vertical-align: top;
 }
 .rs-button-wrap {
   margin-top: 10px;


### PR DESCRIPTION
There's an additional, unintentional margin of about 2 pixels under the icons of the small action buttons.

This improves the layout, so that the icon is set perfectly in the vertical center, and the buttons also make better use of the available space in general.

Before:

![Screenshot from 2020-03-01 11-32-59](https://user-images.githubusercontent.com/842/75629584-2bc6a880-5bb1-11ea-886f-1bf99b87d737.png)

After:

![Screenshot from 2020-03-01 11-41-13](https://user-images.githubusercontent.com/842/75629650-ac85a480-5bb1-11ea-9b98-902b3beeb847.png)