### PR TITLE
Fix alternative positioning

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1,6 +1,5 @@
 #remotestorage-widget {
   z-index: 21000000;
-  position: fixed;
 }
 
 .rs-widget {


### PR DESCRIPTION
I would guess I added that `position: fixed` in order to have the widget float on top with the backdrop over the page, while the rest could be scrolled in theory. In any case, it broke the layout when putting the widget in other positions, like e.g. centered, or on the page bottom.

fixes #106