### PR TITLE
Fix modal backdrop overlaying widget content

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1,5 +1,6 @@
 #remotestorage-widget {
   z-index: 21000000;
+  position: relative;
 }
 
 .rs-widget {

--- a/src/widget.js
+++ b/src/widget.js
@@ -1,3 +1,7 @@
+const style = document.createElement('style');
+style.innerHTML = require('raw-loader!./assets/styles.css').default;
+document.head.insertBefore(style, document.head.firstChild);
+
 /**
  * RemoteStorage connect widget
  * @constructor
@@ -172,10 +176,6 @@ Widget.prototype = {
     const element = document.createElement('div');
     element.id = "remotestorage-widget";
     element.innerHTML = require('html-loader!./assets/widget.html');
-
-    const style = document.createElement('style');
-    style.innerHTML = require('raw-loader!./assets/styles.css').default;
-    element.appendChild(style);
 
     return element;
   },


### PR DESCRIPTION
 Ensure the zIndex is honored for the widget so it stays above the modal backdrop.

fixes #109
fixes #110