### PR TITLE
Fix modal backdrop display

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -374,8 +374,7 @@ polygon.rs-logo-shape,
 
 .remotestorage-widget-modal-backdrop {
   display: none;
-  z-index: 20000000;
-  position: absolute;
+  position: fixed;
   top: 0;
   bottom: 0;
   left: 0;

--- a/src/assets/widget.html
+++ b/src/assets/widget.html
@@ -1,3 +1,5 @@
+<div class="remotestorage-widget-modal-backdrop"></div>
+
 <!--
   rs-state-initial
   rs-state-choose

--- a/src/widget.js
+++ b/src/widget.js
@@ -175,18 +175,6 @@ Widget.prototype = {
   },
 
   /**
-   * Create the widget's modal backdrop element, add
-   * styling, and append to DOM
-   *
-   * @private
-   */
-  createBackdropHtml () {
-    const backdropEl = document.createElement('div');
-    backdropEl.classList.add('remotestorage-widget-modal-backdrop');
-    document.body.appendChild(backdropEl);
-  },
-
-  /**
    * Sets the `rs-modal` class on the widget element.
    * Done by default for small screens (max-width 420px).
    *
@@ -270,7 +258,6 @@ Widget.prototype = {
    * @param  {String} [elementId] - Widget's parent
    */
   attach (elementId) {
-    this.createBackdropHtml()
     const domElement = this.createHtmlTemplate();
 
     let parentContainerEl;


### PR DESCRIPTION
Place the modal backdrop element inside the widget container, so that even if the widget is attached to positioned elements, the modal backdrop does not display over the widget contents.

I think this approach is better to fix the problem as it does not require the developers to apply any hacks.

I should note that i don't have much experience with styling, so i don't know if placing the backdrop inside the widget can cause other display issues that i can't think of.

Fixes #109
Fixes #110

