### PR TITLE
Improves compliance with Google SEO guidelines

### DIFF
--- a/src/assets/widget.html
+++ b/src/assets/widget.html
@@ -261,8 +261,8 @@
     <div class="rs-content">
       <h1 class="rs-big-headline">Connect your storage</h1>
       <p class="rs-short-desc">
-        This app allows you to sync data with a storage of your choice.
-        <a class="rs-help" href="https://remotestorage.io/" target="_blank">Read more</a>
+        This app allows you to sync data with a
+        <a class="rs-help" href="https://remotestorage.io/" target="_blank" rel="noopener">storage provider of your choice</a>.
       </p>
       <div class="rs-button-wrap">
         <button class="rs-button rs-button-big rs-choose-rs">
@@ -477,7 +477,7 @@
         <input type="text" name="rs-user-address" placeholder="user@provider.com" autocapitalize="off">
         <div class="rs-sign-in-error rs-hidden"></div>
         <button type="submit" class="rs-connect">Connect</button>
-        <a href="https://remotestorage.io/get/" class="rs-help" target="_blank">Need help?</a>
+        <a href="https://remotestorage.io/get/" class="rs-help" target="_blank" rel="noopener">Need help?</a>
       </form>
     </div>
   </div>


### PR DESCRIPTION
Running Lighthouse (https://developers.google.com/web/tools/lighthouse) dings all apps using the widget for "Links do not have descriptive text" and "Links to cross-origin destinations are unsafe" (and thus, lowers the search engine ranking of our apps).  These suggestions are in-line with other web usability guidelines, so I've implemented them.