### PR TITLE
Fix wrong display attribute values in CSS

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -52,21 +52,20 @@
   transition: margin-left 300ms ease-out, transform 300ms ease-out;
   cursor: pointer;
 }
-.rs-widget .rs-backend-remotestorage svg#rs-main-logo-remotestorage,
-{
-  display: normal;
+.rs-widget .rs-backend-remotestorage svg#rs-main-logo-remotestorage {
+  display: block;
 }
 .rs-widget[class*="rs-backend-"]:not(.rs-backend-remotestorage) svg#rs-main-logo-remotestorage {
   display: none;
 }
 .rs-widget.rs-backend-dropbox svg#rs-main-logo-dropbox {
-  display: normal;
+  display: block;
 }
 .rs-widget:not(.rs-backend-dropbox) svg#rs-main-logo-dropbox {
   display: none;
 }
 .rs-widget.rs-backend-googledrive svg#rs-main-logo-googledrive {
-  display: normal;
+  display: block;
 }
 .rs-widget:not(.rs-backend-googledrive) svg#rs-main-logo-googledrive {
   display: none;


### PR DESCRIPTION
Hello ; I keep getting those pesky CSS warnings:

- Selector expected.  Ruleset ignored due to bad selector.
- Error in parsing value for 'display'.  Declaration dropped. (x2)

So I removed a trailing comma, and changed "normal" (which is not a valid attr. for `display`) to "block" (the default value).

Cheers ; PS RemoteStorage is fantastic, thanks a **lot**.