### PR TITLE
Fix button visible while widget closed (in Firefox)

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -37,7 +37,7 @@
   max-height: 0px;
 }
 
-.rs-box.rs-selected {
+.rs-box.rs-selected:not([aria-hidden=true]) {
   opacity: 1;
   max-height: 420px;
 }


### PR DESCRIPTION
Since a recent new version of Firefox, some of widget's content elements are visible, while the widget is closed, due to a CSS selector being prioritized differently now. Here's what it looks like in Webmarks and Sharesome for example:

![Screenshot from 2022-09-20 12-44-58](https://user-images.githubusercontent.com/842/191238220-6b30a618-9adc-465d-9b2e-033353a315f2.png) ![Screenshot from 2022-09-20 12-45-23](https://user-images.githubusercontent.com/842/191238209-26fd385f-5e01-49a7-bddf-228fee989519.png)

This adds an additional selector to prevent overriding attributes when the widget content area is hidden.