### PR TITLE
Simplify/improve sync status in widget UI

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -527,17 +527,12 @@ class Widget {
     const now = new Date();
     if (this.online) {
       this.lastSynced = now;
-      this.rsConnectedLabel.textContent = 'Synced just now';
-      return;
-    }
-    if (!this.lastSynced) {
+      this.rsConnectedLabel.textContent = 'Synced';
+    } else {
       if (!this.rsWidget.classList.contains('rs-state-unauthorized')) {
         this.rsConnectedLabel.textContent = 'Offline';
       }
-      return;
     }
-    const secondsSinceLastSync = Math.round((now.getTime() - this.lastSynced.getTime())/1000);
-    this.rsConnectedLabel.textContent = `Synced ${secondsSinceLastSync} seconds ago`;
   }
 
   isSmallScreen () {


### PR DESCRIPTION
It was bugging me for a long time that the widget would always say "synced just now" and then show "synced 20, 30, 120... seconds ago" later.

I changed it to just "synced" and "offline", and it immediately felt much, *much* better than before.

WDYT?