### PR TITLE
Guards against falsy msgs when handling 'sync-done' and 'error" events

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -67,7 +67,7 @@ class Widget {
         this.handleSyncStarted();
         break;
       case 'sync-done':
-        if (this.online && !msg.completed) return;
+        if (this.online && !msg?.completed) return;
         this.syncInProgress = false;
         this.rsSyncButton.classList.remove("rs-rotate");
         this.updateLastSyncedStatus();
@@ -108,11 +108,11 @@ class Widget {
       case 'error':
         this.setBackendClass(this.rs.backend);
 
-        if (msg.name === 'DiscoveryError') {
+        if (msg?.name === 'DiscoveryError') {
           this.handleDiscoveryError(msg);
-        } else if (msg.name === 'SyncError') {
+        } else if (msg?.name === 'SyncError') {
           this.handleSyncError(msg);
-        } else if (msg.name === 'Unauthorized') {
+        } else if (msg?.name === 'Unauthorized') {
           this.handleUnauthorized(msg);
         } else {
           console.debug(`Encountered unhandled error: "${msg}"`);


### PR DESCRIPTION
Why: In remotestorage.js, in dropbox.ts, on lines 1010 and 1113, emits 'sync-done' with an undefined message. indexeddb.ts, on line 403 emits an error event where err is falsy. There are also several catch blocks that emit an 'error' event with whatever was thrown. Usually that would be an Error object, but it's entirely possible for code to throw null or undefined.

I've also observed the message to 'sync-done' being undefined in the wild, but it was not clear what the original source of the problem was.